### PR TITLE
[IE-64995] chore: add semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,11 @@
+---
+name: Release semantic-release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  semantic-release:
+    uses: careem/shared-workflows/.github/workflows/semantic-release.yaml@master
+    secrets: inherit

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,10 @@
+---
+branches:
+  - main
+repositoryUrl: https://github.com/careem/ecr-create-repository-action
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/github"
+  - - "@semantic-release/exec"
+    - prepareCmd: 'echo "new-tag=${nextRelease.version}" >> "$GITHUB_ENV"'


### PR DESCRIPTION
## Summary
- Adds `.releaserc.yml` configured for the `main` branch, using `commit-analyzer`, `release-notes-generator`, `github`, and `exec` plugins
- Adds `.github/workflows/semantic-release.yaml` that triggers on push to `main` via `careem/shared-workflows`

Modelled after the setup in `careem/docker-kong`.

## How it works
Merging a conventional commit to `main` (e.g. `feat:`, `fix:`, `chore:`) triggers semantic-release to automatically determine the next version, create a GitHub Release, and tag the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)