### PR TITLE
chore: add workflow_dispatch to semantic-release workflow

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -4,6 +4,7 @@ name: Release semantic-release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   semantic-release:


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to the semantic-release workflow so it can be manually triggered from the GitHub Actions UI or via `gh workflow run`.

This also serves as a workaround while investigating why the push-triggered run failed (likely `vars.DEVX_GITHUB_RUNNERS_CONFIG` not set for this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)