### PR TITLE
[IE-64995] fix: inline semantic-release steps to fix 0-jobs failure

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -8,5 +8,27 @@ on:
 
 jobs:
   semantic-release:
-    uses: careem/shared-workflows/.github/workflows/semantic-release.yaml@master
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.10.0"
+
+      - name: Install semantic-release
+        run: |
+          npm install -g semantic-release \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            @semantic-release/github \
+            @semantic-release/git \
+            @semantic-release/exec
+
+      - name: Run semantic-release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The semantic-release workflow was failing with **0 jobs / "workflow file issue"** on every push to `main`.

**Root cause**: `careem/shared-workflows` picks its runner via `${{ fromJSON(vars.DEVX_GITHUB_RUNNERS_CONFIG)['ci-micro'].runner }}`. This variable is set in repos like `docker-kong` (self-hosted runners) but **not** in `ecr-create-repository-action`. When GitHub can't evaluate the runner expression it fails the entire reusable workflow before any jobs start.

## Fix
Inline the semantic-release steps directly on `ubuntu-latest`, removing the dependency on the shared workflow runner infrastructure. Node version and plugins match what `careem/shared-workflows/actions/semantic-release` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)